### PR TITLE
Allow to iterate on read

### DIFF
--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -240,6 +240,10 @@ impl ReadHdfsFile {
 
 impl Read for ReadHdfsFile {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        
+        if self.pos == self.len {
+            return Ok(0);
+        }
 
         let buf_len: i64 = buf.len().try_into().map_err(|_| IoError::new(IoErrorKind::InvalidInput, "buffer too big"))?;
         let s = self.cx.open(&self.path, OpenOptions::new().offset(self.pos).length(buf_len))?;


### PR DESCRIPTION
Hello,

Thank you very much for this crate, it helps me a lot.

I needed to read a file on HDFS line by line, so I wrap a ReadHdfsFile in a BufReader like this:

```rust
        let cx = SyncHdfsClientBuilder::new("INTERNAL_URI".parse().unwrap())
            .user_name("hdfs".to_owned())
            .build()
            .unwrap();

        let file = ReadHdfsFile::open(cx, path_without_hdfs.to_owned()).unwrap();
        let iterator = BufReader::new(file).lines();
        ...
```

But the webhdfs is returning a 403 when you go after the end of the file, thus read cannot return an `Ok(0)` and the iteration does not end well.

This fix allow to put the file on a BufReader to iterate it by pro-actively returning `Ok(0)`.


Sorry I did not manage to execute integration tests.


Best,

